### PR TITLE
Setup Express backend with Sequelize models

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=carddb
+DB_USER=user
+DB_PASS=password
+JWT_SECRET=secretkey

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -1,0 +1,20 @@
+require('dotenv').config();
+
+module.exports = {
+  development: {
+    username: process.env.DB_USER,
+    password: process.env.DB_PASS,
+    database: process.env.DB_NAME,
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT,
+    dialect: 'postgres'
+  },
+  production: {
+    username: process.env.DB_USER,
+    password: process.env.DB_PASS,
+    database: process.env.DB_NAME,
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT,
+    dialect: 'postgres'
+  }
+};

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,0 +1,24 @@
+const jwt = require('jsonwebtoken');
+const { User } = require('../models');
+
+exports.register = async (req, res) => {
+  try {
+    const user = await User.create(req.body);
+    res.json({ id: user.id, username: user.username });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+exports.login = async (req, res) => {
+  try {
+    const user = await User.findOne({ where: { username: req.body.username } });
+    if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+    const match = await require('bcrypt').compare(req.body.password, user.password);
+    if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+    const token = jwt.sign({ id: user.id }, process.env.JWT_SECRET);
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/backend/controllers/cardController.js
+++ b/backend/controllers/cardController.js
@@ -1,0 +1,33 @@
+const { Card, UserInventory, CardCondition, GradingCompany } = require('../models');
+const { Op } = require('sequelize');
+
+exports.listByCondition = async (req, res) => {
+  try {
+    const conditionId = req.params.conditionId;
+    const cards = await Card.findAll({
+      include: [{
+        model: UserInventory,
+        where: { condition_id: conditionId }
+      }]
+    });
+    res.json(cards);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.listByGrade = async (req, res) => {
+  try {
+    const { company_id, grade } = req.query;
+    const where = {};
+    if (company_id) where.grading_company_id = company_id;
+    if (grade) where.grade_value = grade;
+
+    const cards = await Card.findAll({
+      include: [{ model: UserInventory, where, include: [GradingCompany] }]
+    });
+    res.json(cards);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/backend/controllers/inventoryController.js
+++ b/backend/controllers/inventoryController.js
@@ -1,0 +1,34 @@
+const { UserInventory, Card, CardCondition, GradingCompany } = require('../models');
+
+exports.listInventory = async (req, res) => {
+  try {
+    const userId = req.params.userId;
+    const inventory = await UserInventory.findAll({
+      where: { user_id: userId },
+      include: [Card, CardCondition, GradingCompany]
+    });
+    res.json(inventory);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.addCard = async (req, res) => {
+  try {
+    const item = await UserInventory.create(req.body);
+    res.json(item);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+exports.updateCard = async (req, res) => {
+  try {
+    const id = req.params.id;
+    await UserInventory.update(req.body, { where: { id } });
+    const item = await UserInventory.findByPk(id);
+    res.json(item);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,14 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ error: 'No token' });
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.userId = decoded.id;
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+};

--- a/backend/migrations/001-create-users.js
+++ b/backend/migrations/001-create-users.js
@@ -1,0 +1,33 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('Users', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      username: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true
+      },
+      password: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('Users');
+  }
+};

--- a/backend/migrations/002-create-cards.js
+++ b/backend/migrations/002-create-cards.js
@@ -1,0 +1,29 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('Cards', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      description: Sequelize.STRING,
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('Cards');
+  }
+};

--- a/backend/migrations/003-create-card-conditions.js
+++ b/backend/migrations/003-create-card-conditions.js
@@ -1,0 +1,29 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('CardConditions', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('CardConditions');
+  }
+};

--- a/backend/migrations/004-create-grading-companies.js
+++ b/backend/migrations/004-create-grading-companies.js
@@ -1,0 +1,29 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('GradingCompanies', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('GradingCompanies');
+  }
+};

--- a/backend/migrations/005-create-user-inventory.js
+++ b/backend/migrations/005-create-user-inventory.js
@@ -1,0 +1,53 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('UserInventories', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Users', key: 'id' }
+      },
+      card_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Cards', key: 'id' }
+      },
+      condition_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'CardConditions', key: 'id' }
+      },
+      grading_company_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'GradingCompanies', key: 'id' }
+      },
+      grade_value: {
+        type: Sequelize.DECIMAL
+      },
+      quantity: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 1
+      },
+      obtained_date: Sequelize.DATE,
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('UserInventories');
+  }
+};

--- a/backend/models/card.js
+++ b/backend/models/card.js
@@ -1,0 +1,15 @@
+module.exports = (sequelize, DataTypes) => {
+  const Card = sequelize.define('Card', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    description: DataTypes.STRING
+  }, {});
+
+  Card.associate = models => {
+    Card.hasMany(models.UserInventory, { foreignKey: 'card_id' });
+  };
+
+  return Card;
+};

--- a/backend/models/card_condition.js
+++ b/backend/models/card_condition.js
@@ -1,0 +1,15 @@
+module.exports = (sequelize, DataTypes) => {
+  const CardCondition = sequelize.define('CardCondition', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    }
+  }, {});
+
+  CardCondition.associate = models => {
+    CardCondition.hasMany(models.UserInventory, { foreignKey: 'condition_id' });
+  };
+
+  return CardCondition;
+};

--- a/backend/models/grading_company.js
+++ b/backend/models/grading_company.js
@@ -1,0 +1,15 @@
+module.exports = (sequelize, DataTypes) => {
+  const GradingCompany = sequelize.define('GradingCompany', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    }
+  }, {});
+
+  GradingCompany.associate = models => {
+    GradingCompany.hasMany(models.UserInventory, { foreignKey: 'grading_company_id' });
+  };
+
+  return GradingCompany;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
+const env = process.env.NODE_ENV || 'development';
+const config = require('../config/config')[env];
+
+const sequelize = new Sequelize(config.database, config.username, config.password, config);
+const db = {};
+
+fs.readdirSync(__dirname)
+  .filter(file => file !== 'index.js' && file.endsWith('.js'))
+  .forEach(file => {
+    const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
+    db[model.name] = model;
+  });
+
+Object.keys(db).forEach(modelName => {
+  if (db[modelName].associate) {
+    db[modelName].associate(db);
+  }
+});
+
+db.sequelize = sequelize;
+db.Sequelize = Sequelize;
+
+module.exports = db;

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,0 +1,26 @@
+const bcrypt = require('bcrypt');
+
+module.exports = (sequelize, DataTypes) => {
+  const User = sequelize.define('User', {
+    username: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
+    password: {
+      type: DataTypes.STRING,
+      allowNull: false
+    }
+  }, {});
+
+  User.beforeCreate(async user => {
+    const salt = await bcrypt.genSalt(10);
+    user.password = await bcrypt.hash(user.password, salt);
+  });
+
+  User.associate = models => {
+    User.hasMany(models.UserInventory, { foreignKey: 'user_id' });
+  };
+
+  return User;
+};

--- a/backend/models/user_inventory.js
+++ b/backend/models/user_inventory.js
@@ -1,0 +1,20 @@
+module.exports = (sequelize, DataTypes) => {
+  const UserInventory = sequelize.define('UserInventory', {
+    quantity: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1
+    },
+    grade_value: DataTypes.DECIMAL,
+    obtained_date: DataTypes.DATE
+  }, {});
+
+  UserInventory.associate = models => {
+    UserInventory.belongsTo(models.User, { foreignKey: 'user_id' });
+    UserInventory.belongsTo(models.Card, { foreignKey: 'card_id' });
+    UserInventory.belongsTo(models.CardCondition, { foreignKey: 'condition_id' });
+    UserInventory.belongsTo(models.GradingCompany, { foreignKey: 'grading_company_id' });
+  };
+
+  return UserInventory;
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "card-vending-backend",
+  "version": "1.0.0",
+  "description": "Backend for collectible card system",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "sequelize": "^6.32.1",
+    "pg": "^8.11.1",
+    "pg-hstore": "^2.3.4",
+    "jsonwebtoken": "^9.0.1",
+    "bcrypt": "^5.1.0",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const authController = require('../controllers/authController');
+
+router.post('/register', authController.register);
+router.post('/login', authController.login);
+
+module.exports = router;

--- a/backend/routes/cards.js
+++ b/backend/routes/cards.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const cardController = require('../controllers/cardController');
+const auth = require('../middleware/auth');
+
+router.get('/condition/:conditionId', auth, cardController.listByCondition);
+router.get('/grade', auth, cardController.listByGrade);
+
+module.exports = router;

--- a/backend/routes/inventory.js
+++ b/backend/routes/inventory.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const inventoryController = require('../controllers/inventoryController');
+const auth = require('../middleware/auth');
+
+router.get('/:userId', auth, inventoryController.listInventory);
+router.post('/', auth, inventoryController.addCard);
+router.put('/:id', auth, inventoryController.updateCard);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,16 @@
+require('dotenv').config();
+const express = require('express');
+const app = express();
+const { sequelize } = require('./models');
+
+app.use(express.json());
+
+app.use('/auth', require('./routes/auth'));
+app.use('/inventory', require('./routes/inventory'));
+app.use('/cards', require('./routes/cards'));
+
+const PORT = process.env.PORT || 3000;
+
+sequelize.sync().then(() => {
+  app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+});


### PR DESCRIPTION
## Summary
- add backend structure with Express and Sequelize
- create models and migrations for users, cards, card conditions, grading companies and inventories
- setup auth, inventory and card controllers and routes
- provide JWT-based auth middleware
- example environment configuration

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684dc0362914832bbe630ff7d6eb19c2