### PR TITLE
Add React frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/frontend/node_modules
+frontend/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-Prueba
+# Card Vending Machine
+
+This repository contains a basic frontend built with React and TailwindCSS.
+
+## Development
+
+1. Navigate to the `frontend` folder and install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+The SPA expects a backend with the following endpoints:
+- `POST /api/login`
+- `POST /api/register`
+- `GET /api/cards`
+- `POST /api/cards`
+
+Adjust the base URL in the fetch calls if your backend is hosted elsewhere.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,12 @@
+# Frontend SPA
+
+This React project uses Vite and TailwindCSS.
+
+## Setup
+
+Install dependencies in this folder and start the dev server:
+
+```bash
+npm install
+npm run dev
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Card Inventory</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "card-vending-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.2.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.27",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,37 @@
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Login from './pages/Login';
+import Register from './pages/Register';
+import Dashboard from './pages/Dashboard';
+import AddCard from './pages/AddCard';
+import { useAuth } from './context/AuthContext';
+
+function PrivateRoute({ children }) {
+  const { user } = useAuth();
+  return user ? children : <Navigate to="/login" />;
+}
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/register" element={<Register />} />
+      <Route
+        path="/dashboard"
+        element={
+          <PrivateRoute>
+            <Dashboard />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/add-card"
+        element={
+          <PrivateRoute>
+            <AddCard />
+          </PrivateRoute>
+        }
+      />
+      <Route path="*" element={<Navigate to="/dashboard" />} />
+    </Routes>
+  );
+}

--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -1,0 +1,12 @@
+export default function CardItem({ card }) {
+  return (
+    <div className="border rounded p-2 flex gap-2 items-center">
+      <img src={card.image} alt={card.name} className="w-16 h-16 object-cover" />
+      <div className="flex-1">
+        <h3 className="font-semibold">{card.name}</h3>
+        <p className="text-sm">{card.condition} - {card.grade}</p>
+      </div>
+      <span className="font-bold">x{card.quantity}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/InventoryList.jsx
+++ b/frontend/src/components/InventoryList.jsx
@@ -1,0 +1,12 @@
+import CardItem from './CardItem';
+
+export default function InventoryList({ cards }) {
+  if (!cards.length) return <p>No cards found.</p>;
+  return (
+    <div className="grid gap-2">
+      {cards.map(card => (
+        <CardItem key={card.id} card={card} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/StatsPanel.jsx
+++ b/frontend/src/components/StatsPanel.jsx
@@ -1,0 +1,22 @@
+export default function StatsPanel({ stats }) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+      <div className="bg-white p-4 rounded shadow">
+        <h4 className="text-sm">Total Cards</h4>
+        <p className="text-xl font-bold">{stats.total}</p>
+      </div>
+      <div className="bg-white p-4 rounded shadow">
+        <h4 className="text-sm">By Rarity</h4>
+        {Object.entries(stats.byRarity).map(([rarity, count]) => (
+          <p key={rarity}>{rarity}: {count}</p>
+        ))}
+      </div>
+      <div className="bg-white p-4 rounded shadow">
+        <h4 className="text-sm">By Condition</h4>
+        {Object.entries(stats.byCondition).map(([cond, count]) => (
+          <p key={cond}>{cond}: {count}</p>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,47 @@
+import { createContext, useState, useContext } from 'react';
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+
+  const login = async (email, password) => {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUser(data);
+    } else {
+      throw new Error('Login failed');
+    }
+  };
+
+  const register = async (email, password) => {
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUser(data);
+    } else {
+      throw new Error('Registration failed');
+    }
+  };
+
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+import { AuthProvider } from './context/AuthContext';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/AddCard.jsx
+++ b/frontend/src/pages/AddCard.jsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const conditions = ['Near Mint', 'Excellent', 'Good', 'Played'];
+const grades = ['PSA 10', 'PSA 9', 'PSA 8', 'Ungraded'];
+
+export default function AddCard() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [image, setImage] = useState('');
+  const [condition, setCondition] = useState(conditions[0]);
+  const [grade, setGrade] = useState(grades[0]);
+  const [quantity, setQuantity] = useState(1);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/cards', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${user.token}`,
+        },
+        body: JSON.stringify({ name, image, condition, grade, quantity }),
+      });
+      if (!res.ok) throw new Error('Failed to add card');
+      navigate('/dashboard');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Add New Card</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-2 max-w-md">
+        <input
+          className="border p-2 w-full"
+          placeholder="Name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Image URL"
+          value={image}
+          onChange={e => setImage(e.target.value)}
+        />
+        <select
+          className="border p-2 w-full"
+          value={condition}
+          onChange={e => setCondition(e.target.value)}
+        >
+          {conditions.map(c => (
+            <option key={c}>{c}</option>
+          ))}
+        </select>
+        <select
+          className="border p-2 w-full"
+          value={grade}
+          onChange={e => setGrade(e.target.value)}
+        >
+          {grades.map(g => (
+            <option key={g}>{g}</option>
+          ))}
+        </select>
+        <input
+          type="number"
+          className="border p-2 w-full"
+          value={quantity}
+          onChange={e => setQuantity(parseInt(e.target.value))}
+        />
+        <button className="bg-blue-500 text-white px-4 py-2">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import InventoryList from '../components/InventoryList';
+import StatsPanel from '../components/StatsPanel';
+
+const conditions = ['All', 'Near Mint', 'Excellent', 'Good', 'Played'];
+const grades = ['All', 'PSA 10', 'PSA 9', 'PSA 8', 'Ungraded'];
+
+export default function Dashboard() {
+  const { user, logout } = useAuth();
+  const [cards, setCards] = useState([]);
+  const [filtered, setFiltered] = useState([]);
+  const [condition, setCondition] = useState('All');
+  const [grade, setGrade] = useState('All');
+  const [stats, setStats] = useState({ total: 0, byRarity: {}, byCondition: {} });
+
+  useEffect(() => {
+    const fetchCards = async () => {
+      const res = await fetch('/api/cards', {
+        headers: { Authorization: `Bearer ${user.token}` },
+      });
+      const data = await res.json();
+      setCards(data);
+      setFiltered(data);
+      computeStats(data);
+    };
+    fetchCards();
+  }, [user]);
+
+  useEffect(() => {
+    let result = cards;
+    if (condition !== 'All') result = result.filter(c => c.condition === condition);
+    if (grade !== 'All') result = result.filter(c => c.grade === grade);
+    setFiltered(result);
+  }, [condition, grade, cards]);
+
+  const computeStats = data => {
+    const total = data.reduce((sum, c) => sum + c.quantity, 0);
+    const byRarity = {};
+    const byCondition = {};
+    data.forEach(c => {
+      byRarity[c.rarity] = (byRarity[c.rarity] || 0) + c.quantity;
+      byCondition[c.condition] = (byCondition[c.condition] || 0) + c.quantity;
+    });
+    setStats({ total, byRarity, byCondition });
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl">Dashboard</h1>
+        <div>
+          <button className="mr-2" onClick={logout}>Logout</button>
+          <Link to="/add-card" className="bg-blue-500 text-white px-4 py-1 rounded">Add Card</Link>
+        </div>
+      </div>
+
+      <StatsPanel stats={stats} />
+
+      <div className="flex gap-2">
+        <select className="border p-2" value={condition} onChange={e => setCondition(e.target.value)}>
+          {conditions.map(c => <option key={c}>{c}</option>)}
+        </select>
+        <select className="border p-2" value={grade} onChange={e => setGrade(e.target.value)}>
+          {grades.map(g => <option key={g}>{g}</option>)}
+        </select>
+      </div>
+
+      <InventoryList cards={filtered} />
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export default function Login() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    try {
+      await login(email, password);
+      navigate('/dashboard');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-100">
+      <form onSubmit={handleSubmit} className="bg-white p-8 rounded shadow-md w-80">
+        <h1 className="text-2xl mb-4">Login</h1>
+        {error && <p className="text-red-500">{error}</p>}
+        <input
+          type="email"
+          placeholder="Email"
+          className="border p-2 w-full mb-2"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="border p-2 w-full mb-2"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white w-full py-2">Login</button>
+        <p className="mt-4 text-center">
+          No account? <Link to="/register" className="text-blue-500">Register</Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export default function Register() {
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    try {
+      await register(email, password);
+      navigate('/dashboard');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-100">
+      <form onSubmit={handleSubmit} className="bg-white p-8 rounded shadow-md w-80">
+        <h1 className="text-2xl mb-4">Register</h1>
+        {error && <p className="text-red-500">{error}</p>}
+        <input
+          type="email"
+          placeholder="Email"
+          className="border p-2 w-full mb-2"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="border p-2 w-full mb-2"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white w-full py-2">Register</button>
+        <p className="mt-4 text-center">
+          Have an account? <Link to="/login" className="text-blue-500">Login</Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- add React/Vite frontend with TailwindCSS
- include authentication context and pages for login/register
- add dashboard with inventory, filters, statistics and add-card form
- document development steps

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_684dc0434f3c832bbabd56d89d04728a