### PR TITLE
Switch backend to MySQL

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,5 @@
 DB_HOST=localhost
-DB_PORT=5432
+DB_PORT=3306
 DB_NAME=carddb
 DB_USER=user
 DB_PASS=password

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -7,7 +7,7 @@ module.exports = {
     database: process.env.DB_NAME,
     host: process.env.DB_HOST,
     port: process.env.DB_PORT,
-    dialect: 'postgres'
+    dialect: 'mysql'
   },
   production: {
     username: process.env.DB_USER,
@@ -15,6 +15,6 @@ module.exports = {
     database: process.env.DB_NAME,
     host: process.env.DB_HOST,
     port: process.env.DB_PORT,
-    dialect: 'postgres'
+    dialect: 'mysql'
   }
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "sequelize": "^6.32.1",
-    "pg": "^8.11.1",
-    "pg-hstore": "^2.3.4",
+    "mysql2": "^3.9.4",
     "jsonwebtoken": "^9.0.1",
     "bcrypt": "^5.1.0",
     "dotenv": "^16.3.1"


### PR DESCRIPTION
## Summary
- use MySQL dialect in the backend config
- update example environment variables for MySQL
- replace Postgres dependencies with `mysql2`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc210b15c832ba0e6142c44b5712a