### PR TITLE
Fix API path

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -5,9 +5,12 @@ const { sequelize } = require('./models');
 
 app.use(express.json());
 
-app.use('/auth', require('./routes/auth'));
-app.use('/inventory', require('./routes/inventory'));
-app.use('/cards', require('./routes/cards'));
+// Mount all API routes under a common `/api` prefix so the frontend can
+// fetch endpoints like `/api/register` or `/api/cards` as documented in the
+// project README.
+app.use('/api', require('./routes/auth'));
+app.use('/api/inventory', require('./routes/inventory'));
+app.use('/api/cards', require('./routes/cards'));
 
 const PORT = process.env.PORT || 3000;
 


### PR DESCRIPTION
## Summary
- expose backend routes under `/api` prefix so they match the SPA's fetch calls

## Testing
- `npm test` in backend
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dc57b72a8832b9474b22ebdeb9dc2