### PR TITLE
Fix CORS origin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This repository contains a basic frontend built with React and TailwindCSS.
    npm run dev
    ```
 
+The backend uses CORS and expects the frontend to run on `http://localhost:5173` by default.
+If your frontend runs on a different origin, set the `CORS_ORIGIN` variable in the backend
+`.env` file accordingly.
+
 The SPA expects a backend with the following endpoints:
 - `POST /api/login`
 - `POST /api/register`

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,4 @@ DB_NAME=cardb
 DB_USER=card
 DB_PASS=090909mM*@
 JWT_SECRET=secretkey
+CORS_ORIGIN=http://localhost:5173

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,8 +6,10 @@ const { sequelize } = require('./models');
 const app = express();
 
 // 👇 aplicar CORS (ajusta el origen según dónde corre tu frontend)
+//   permite sobreescribir con la variable de entorno CORS_ORIGIN
+const allowedOrigin = process.env.CORS_ORIGIN || 'http://localhost:5173';
 app.use(cors({
-  origin: 'http://localhost:5173', // frontend (Vite)
+  origin: allowedOrigin,
   credentials: true                // si usas cookies o JWT en headers
 }));
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000,
+    // Use Vite's default port (5173) to match the backend CORS configuration
+    port: 5173,
   },
 });


### PR DESCRIPTION
## Summary
- use the default Vite port 5173
- allow overriding CORS origin via `CORS_ORIGIN`
- document CORS origin in README

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_684dc9aadc14832bbf83849db6f5918c